### PR TITLE
feat: add serialization for Program and SharedProgramData data types

### DIFF
--- a/vm/src/hint_processor/hint_processor_definition.rs
+++ b/vm/src/hint_processor/hint_processor_definition.rs
@@ -13,6 +13,7 @@ use crate::vm::vm_core::VirtualMachine;
 
 use super::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData;
 use felt::Felt252;
+use serde::{Serialize, Deserialize};
 
 pub trait HintProcessorLogic {
     //Executes the hint which's data is provided by a dynamic structure previously created by compile_hint
@@ -75,7 +76,7 @@ fn get_ids_data(
     Ok(ids_data)
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct HintReference {
     pub offset1: OffsetValue,
     pub offset2: OffsetValue,

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -103,7 +103,7 @@ impl Default for ApTracking {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Identifier {
     pub pc: Option<usize>,
-    #[serde(rename(deserialize = "type"))]
+    #[serde(rename = "type")]
     pub type_: Option<String>,
     #[serde(default)]
     #[serde(deserialize_with = "felt_from_number")]

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -312,9 +312,14 @@ impl<'de> de::Visitor<'de> for ReferenceIdsVisitor {
     where
         A: MapAccess<'de>,
     {
+        //TODO(harsh): remove
+        println!("inside the custom visitor");
+
         let mut data: HashMap<String, usize> = HashMap::new();
 
         while let Some((key, value)) = map.next_entry::<String, usize>()? {
+            //TODO(harsh): remove
+            println!("going for data insertion k: {}, v: {}", key, value);
             data.insert(key, value);
         }
 
@@ -514,7 +519,7 @@ mod tests {
                 "attributes": [],
                 "debug_info": {
                     "instruction_locations": {}
-                }, 
+                },
                 "builtins": [],
                 "data": [
                     "0x480680017fff8000",
@@ -1014,7 +1019,7 @@ mod tests {
                 "attributes": [],
                 "debug_info": {
                     "instruction_locations": {}
-                },  
+                },
                 "builtins": [],
                 "data": [
                 ],
@@ -1095,10 +1100,10 @@ mod tests {
                         "start_pc": 402,
                         "value": "SafeUint256: subtraction overflow"
                     }
-                ], 
+                ],
                 "debug_info": {
                     "instruction_locations": {}
-                },           
+                },
                 "builtins": [],
                 "data": [
                 ],
@@ -1152,7 +1157,7 @@ mod tests {
         let valid_json = r#"
             {
                 "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-                "attributes": [], 
+                "attributes": [],
                 "debug_info": {
                     "file_contents": {},
                     "instruction_locations": {
@@ -1203,7 +1208,7 @@ mod tests {
                             }
                         }
                     }
-                },          
+                },
                 "builtins": [],
                 "data": [
                 ],
@@ -1261,7 +1266,7 @@ mod tests {
         let valid_json = r#"
             {
                 "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
-                "attributes": [], 
+                "attributes": [],
                 "debug_info": {
                     "file_contents": {},
                     "instruction_locations": {
@@ -1308,7 +1313,7 @@ mod tests {
                             }
                         }
                     }
-                },          
+                },
                 "builtins": [],
                 "data": [
                 ],

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -167,6 +167,8 @@ where
 {
 
 
+    // This value can be of 3 possible types
+    // Felt252, Number, None
     #[derive(Serialize, Deserialize)]
     #[serde(untagged)]
     enum Tmp{

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -180,12 +180,19 @@ fn felt_from_number<'de, D>(deserializer: D) -> Result<Option<Felt252>, D::Error
 where
     D: Deserializer<'de>,
 {
+
+
+    #[derive(Serialize, Deserialize)]
+    struct TmpFelt252SerializedValue  {
+        val: BigInt
+    }
+
     #[derive(Serialize, Deserialize)]
     #[serde(untagged)]
     enum Tmp{
         Felt252(Option<Number>),
         SerializedFelt252 {
-            val: BigInt
+            value: TmpFelt252SerializedValue
         }
     }
 
@@ -216,15 +223,14 @@ where
                 }
         }
     },
-    Tmp::SerializedFelt252 { val } => {
-        let value = val.to_str_radix(10);
+    Tmp::SerializedFelt252 { value } => {
+        let value = value.val.to_str_radix(10);
         let value = Felt252::from_str_radix(&value, 10).map_err(|error|{
-            de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", val, error))
+            de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", value, error))
         })?;
         Ok(Some(value))
     }
-
-    }
+}
 }
 
 fn deserialize_scientific_notation(n: Number) -> Option<Felt252> {

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -161,20 +161,6 @@ pub struct HintLocation {
     pub n_prefix_newlines: u32,
 }
 
-// fn serialize_value<S>(value: &Option<Felt252>,serializer: S) -> Result<S::Ok, S::Error>
-//     where S: Serializer
-// {
-//     match value {
-//         Some(value) => {
-//            let value = value.to_str_radix(10);
-//            serializer.serialize_str(&value)
-//         }
-//         None => {
-//             serializer.serialize_none()
-//         }
-//     }
-// }
-
 fn felt_from_number<'de, D>(deserializer: D) -> Result<Option<Felt252>, D::Error>
 where
     D: Deserializer<'de>,
@@ -216,10 +202,6 @@ where
         }
     },
     Tmp::SerializedFelt252 (value ) => {
-        // let value = value.to_str_radix(10);
-        // let value = Felt252::from_str_radix(&value, 10).map_err(|error|{
-        //     de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", value, error))
-        // })?;
         Ok(Some(value))
     }
 }
@@ -354,14 +336,9 @@ impl<'de> de::Visitor<'de> for ReferenceIdsVisitor {
     where
         A: MapAccess<'de>,
     {
-        //TODO(harsh): remove
-        println!("inside the custom visitor");
-
         let mut data: HashMap<String, usize> = HashMap::new();
 
         while let Some((key, value)) = map.next_entry::<String, usize>()? {
-            //TODO(harsh): remove
-            println!("going for data insertion k: {}, v: {}", key, value);
             data.insert(key, value);
         }
 

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -18,6 +18,7 @@ use crate::{
 use felt::{Felt252, PRIME_STR};
 use num_traits::float::FloatCore;
 use num_traits::{Num, Pow};
+use serde::Serializer;
 use serde::{de, de::MapAccess, de::SeqAccess, Deserialize, Deserializer, Serialize};
 use serde_json::Number;
 
@@ -106,7 +107,7 @@ pub struct Identifier {
     #[serde(rename(deserialize = "type"))]
     pub type_: Option<String>,
     #[serde(default)]
-    #[serde(deserialize_with = "felt_from_number")]
+    #[serde(serialize_with = "serialize_value",deserialize_with = "felt_from_number")]
     pub value: Option<Felt252>,
 
     pub full_name: Option<String>,
@@ -159,6 +160,20 @@ pub struct InputFile {
 pub struct HintLocation {
     pub location: Location,
     pub n_prefix_newlines: u32,
+}
+
+fn serialize_value<S>(value: &Option<Felt252>,serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer
+{
+    match value {
+        Some(value) => {
+           let value = value.to_str_radix(10);
+           serializer.serialize_str(&value)
+        }
+        None => {
+            serializer.serialize_none()
+        }
+    }
 }
 
 fn felt_from_number<'de, D>(deserializer: D) -> Result<Option<Felt252>, D::Error>

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -183,17 +183,10 @@ where
 
 
     #[derive(Serialize, Deserialize)]
-    struct TmpFelt252SerializedValue  {
-        val: BigInt
-    }
-
-    #[derive(Serialize, Deserialize)]
     #[serde(untagged)]
     enum Tmp{
         Felt252(Option<Number>),
-        SerializedFelt252 {
-            value: TmpFelt252SerializedValue
-        }
+        SerializedFelt252(BigInt)
     }
 
     let n: Tmp = Tmp::deserialize(deserializer)?;
@@ -223,8 +216,8 @@ where
                 }
         }
     },
-    Tmp::SerializedFelt252 { value } => {
-        let value = value.val.to_str_radix(10);
+    Tmp::SerializedFelt252 (value ) => {
+        let value = value.to_str_radix(10);
         let value = Felt252::from_str_radix(&value, 10).map_err(|error|{
             de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", value, error))
         })?;

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -106,7 +106,7 @@ pub struct Identifier {
     #[serde(rename(deserialize = "type"))]
     pub type_: Option<String>,
     #[serde(default)]
-    #[serde(deserialize_with = "felt_from_number")]
+    // #[serde(deserialize_with = "felt_from_number")]
     pub value: Option<Felt252>,
 
     pub full_name: Option<String>,
@@ -165,6 +165,16 @@ fn felt_from_number<'de, D>(deserializer: D) -> Result<Option<Felt252>, D::Error
 where
     D: Deserializer<'de>,
 {
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum Tmp
+    {
+        Option<>
+    }
+
+
+
     let n = Number::deserialize(deserializer)?;
     match Felt252::parse_bytes(n.to_string().as_bytes(), 10) {
         Some(x) => Ok(Some(x)),

--- a/vm/src/serde/deserialize_program.rs
+++ b/vm/src/serde/deserialize_program.rs
@@ -16,7 +16,6 @@ use crate::{
     },
 };
 use felt::{Felt252, PRIME_STR};
-use num_bigint::BigInt;
 use num_traits::float::FloatCore;
 use num_traits::{Num, Pow};
 use serde::{de, de::MapAccess, de::SeqAccess, Deserialize, Deserializer, Serialize};
@@ -186,7 +185,7 @@ where
     #[serde(untagged)]
     enum Tmp{
         Felt252(Option<Number>),
-        SerializedFelt252(BigInt)
+        SerializedFelt252(Felt252)
     }
 
     let n: Tmp = Tmp::deserialize(deserializer)?;
@@ -217,10 +216,10 @@ where
         }
     },
     Tmp::SerializedFelt252 (value ) => {
-        let value = value.to_str_radix(10);
-        let value = Felt252::from_str_radix(&value, 10).map_err(|error|{
-            de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", value, error))
-        })?;
+        // let value = value.to_str_radix(10);
+        // let value = Felt252::from_str_radix(&value, 10).map_err(|error|{
+        //     de::Error::custom(format!("failed to convert big {} to type Felt252,\n error: {}", value, error))
+        // })?;
         Ok(Some(value))
     }
 }

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -44,7 +44,7 @@ use std::path::Path;
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct SharedProgramData {
     pub(crate) data: Vec<MaybeRelocatable>,
-    #[serde(deserialize_with = "deserialize_hints")]
+    // #[serde(deserialize_with = "deserialize_hints")]
     pub(crate) hints: HashMap<usize, Vec<HintParams>>,
     pub(crate) main: Option<usize>,
     //start and end labels will only be used in proof-mode
@@ -56,43 +56,43 @@ pub(crate) struct SharedProgramData {
     pub(crate) reference_manager: Vec<HintReference>,
 }
 
-/// Converts the program type from SN API into a Cairo VM-compatible type.
-pub fn deserialize_hints<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<HashMap<usize,Vec<HintParams>>, D::Error> {
+// /// Converts the program type from SN API into a Cairo VM-compatible type.
+// pub fn deserialize_hints<'de, D: Deserializer<'de>>(
+//     deserializer: D,
+// ) -> Result<HashMap<usize,Vec<HintParams>>, D::Error> {
 
-    #[derive(Serialize, Deserialize)]
-    #[serde(untagged)]
-    enum Tmp{
-        StringKey(HashMap<String, Vec<HintParams>>),
-        UsizeKey(HashMap<usize, Vec<HintParams>>)
-    }
+//     #[derive(Serialize, Deserialize)]
+//     #[serde(untagged)]
+//     enum Tmp{
+//         StringKey(HashMap<String, Vec<HintParams>>),
+//         UsizeKey(HashMap<usize, Vec<HintParams>>)
+//     }
 
-    let value = Tmp::deserialize(deserializer)?;
+//     let value = Tmp::deserialize(deserializer)?;
 
-    let result = match value {
-        Tmp::StringKey(value) => {
-            let mut hash_map: HashMap<usize, Vec<HintParams>> = HashMap::new();
-            value.into_iter().for_each(|(k, v)|{
-                //TODO(harsh): is there a way to avoid panic
-                let usize_key=  usize::from_str_radix(&k, 10).unwrap_or_else(|error|{
-                        panic!("failed to parse usize from value {},\n error {}", &k, error)
-                });
+//     let result = match value {
+//         Tmp::StringKey(value) => {
+//             let mut hash_map: HashMap<usize, Vec<HintParams>> = HashMap::new();
+//             value.into_iter().for_each(|(k, v)|{
+//                 //TODO(harsh): is there a way to avoid panic
+//                 let usize_key=  usize::from_str_radix(&k, 10).unwrap_or_else(|error|{
+//                         panic!("failed to parse usize from value {},\n error {}", &k, error)
+//                 });
 
-                hash_map.insert(usize_key, v);
-            });
+//                 hash_map.insert(usize_key, v);
+//             });
 
-            hash_map
-        }
-        Tmp::UsizeKey(value) => {
-            value
-        }
-    };
+//             hash_map
+//         }
+//         Tmp::UsizeKey(value) => {
+//             value
+//         }
+//     };
 
-    Ok(result)
+//     Ok(result)
 
 
-}
+// }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -161,6 +161,18 @@ impl Program {
         self.shared_program_data.data.iter()
     }
 
+    pub fn iter_hints(&self) -> impl Iterator<Item = (&usize, &Vec<HintParams>)> {
+        self.shared_program_data.hints.iter()
+    }
+
+    pub fn iter_error_message_attributes(&self) -> impl Iterator<Item = &Attribute> {
+        self.shared_program_data.error_message_attributes.iter()
+    }
+
+    pub fn iter_reference_manager(&self) -> impl Iterator<Item = &HintReference> {
+        self.shared_program_data.reference_manager.iter()
+    }
+
     pub fn data_len(&self) -> usize {
         self.shared_program_data.data.len()
     }

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -42,7 +42,7 @@ use std::path::Path;
 // failures.
 // Fields in `Program` (other than `SharedProgramData` itself) are used by the main logic.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct SharedProgramData {
+pub struct SharedProgramData {
     pub(crate) data: Vec<MaybeRelocatable>,
     // #[serde(deserialize_with = "deserialize_hints")]
     pub(crate) hints: HashMap<usize, Vec<HintParams>>,

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -43,17 +43,17 @@ use std::path::Path;
 // Fields in `Program` (other than `SharedProgramData` itself) are used by the main logic.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SharedProgramData {
-    pub(crate) data: Vec<MaybeRelocatable>,
+    pub data: Vec<MaybeRelocatable>,
     // #[serde(deserialize_with = "deserialize_hints")]
-    pub(crate) hints: HashMap<usize, Vec<HintParams>>,
-    pub(crate) main: Option<usize>,
+    pub hints: HashMap<usize, Vec<HintParams>>,
+    pub main: Option<usize>,
     //start and end labels will only be used in proof-mode
-    pub(crate) start: Option<usize>,
-    pub(crate) end: Option<usize>,
-    pub(crate) error_message_attributes: Vec<Attribute>,
-    pub(crate) instruction_locations: Option<HashMap<usize, InstructionLocation>>,
-    pub(crate) identifiers: HashMap<String, Identifier>,
-    pub(crate) reference_manager: Vec<HintReference>,
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+    pub error_message_attributes: Vec<Attribute>,
+    pub instruction_locations: Option<HashMap<usize, InstructionLocation>>,
+    pub identifiers: HashMap<String, Identifier>,
+    pub reference_manager: Vec<HintReference>,
 }
 
 // /// Converts the program type from SN API into a Cairo VM-compatible type.

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -96,9 +96,9 @@ pub struct SharedProgramData {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
-    pub(crate) shared_program_data: Arc<SharedProgramData>,
-    pub(crate) constants: HashMap<String, Felt252>,
-    pub(crate) builtins: Vec<BuiltinName>,
+    pub shared_program_data: Arc<SharedProgramData>,
+    pub constants: HashMap<String, Felt252>,
+    pub builtins: Vec<BuiltinName>,
 }
 
 impl Serialize for Program {

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -44,7 +44,6 @@ use std::path::Path;
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SharedProgramData {
     pub data: Vec<MaybeRelocatable>,
-    // #[serde(deserialize_with = "deserialize_hints")]
     pub hints: HashMap<usize, Vec<HintParams>>,
     pub main: Option<usize>,
     //start and end labels will only be used in proof-mode
@@ -56,43 +55,6 @@ pub struct SharedProgramData {
     pub reference_manager: Vec<HintReference>,
 }
 
-// /// Converts the program type from SN API into a Cairo VM-compatible type.
-// pub fn deserialize_hints<'de, D: Deserializer<'de>>(
-//     deserializer: D,
-// ) -> Result<HashMap<usize,Vec<HintParams>>, D::Error> {
-
-//     #[derive(Serialize, Deserialize)]
-//     #[serde(untagged)]
-//     enum Tmp{
-//         StringKey(HashMap<String, Vec<HintParams>>),
-//         UsizeKey(HashMap<usize, Vec<HintParams>>)
-//     }
-
-//     let value = Tmp::deserialize(deserializer)?;
-
-//     let result = match value {
-//         Tmp::StringKey(value) => {
-//             let mut hash_map: HashMap<usize, Vec<HintParams>> = HashMap::new();
-//             value.into_iter().for_each(|(k, v)|{
-//                 //TODO(harsh): is there a way to avoid panic
-//                 let usize_key=  usize::from_str_radix(&k, 10).unwrap_or_else(|error|{
-//                         panic!("failed to parse usize from value {},\n error {}", &k, error)
-//                 });
-
-//                 hash_map.insert(usize_key, v);
-//             });
-
-//             hash_map
-//         }
-//         Tmp::UsizeKey(value) => {
-//             value
-//         }
-//     };
-
-//     Ok(result)
-
-
-// }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
@@ -121,9 +83,6 @@ impl<'de> Deserialize<'de> for Program {
         D: Deserializer<'de>,
     {
 
-        //TODO(harsh): remove
-        println!("reaching in the deserialization of Program");
-
         #[derive(Deserialize)]
         struct InnerProgram {
             pub shared_program_data: SharedProgramData,
@@ -132,9 +91,6 @@ impl<'de> Deserialize<'de> for Program {
         }
 
         let inner_program = InnerProgram::deserialize(deserializer)?;
-
-        //TODO(harsh): remove
-        println!("deserialization succeeded");
 
         Ok(
             Program { shared_program_data: Arc::new(inner_program.shared_program_data),
@@ -206,18 +162,6 @@ impl Program {
 
     pub fn iter_data(&self) -> impl Iterator<Item = &MaybeRelocatable> {
         self.shared_program_data.data.iter()
-    }
-
-    pub fn iter_hints(&self) -> impl Iterator<Item = (&usize, &Vec<HintParams>)> {
-        self.shared_program_data.hints.iter()
-    }
-
-    pub fn iter_error_message_attributes(&self) -> impl Iterator<Item = &Attribute> {
-        self.shared_program_data.error_message_attributes.iter()
-    }
-
-    pub fn iter_reference_manager(&self) -> impl Iterator<Item = &HintReference> {
-        self.shared_program_data.reference_manager.iter()
     }
 
     pub fn data_len(&self) -> usize {

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -83,9 +83,9 @@ impl<'de> Deserialize<'de> for Program {
     {
         #[derive(Deserialize)]
         struct InnerProgram {
-            shared_program_data: SharedProgramData,
-            constants: HashMap<String, Felt252>,
-            builtins: Vec<BuiltinName>,
+            pub shared_program_data: SharedProgramData,
+            pub constants: HashMap<String, Felt252>,
+            pub builtins: Vec<BuiltinName>,
         }
 
         let inner_program = InnerProgram::deserialize(deserializer)?;

--- a/vm/src/types/program.rs
+++ b/vm/src/types/program.rs
@@ -81,6 +81,10 @@ impl<'de> Deserialize<'de> for Program {
     where
         D: Deserializer<'de>,
     {
+
+        //TODO(harsh): remove
+        println!("reaching in the deserialization of Program");
+
         #[derive(Deserialize)]
         struct InnerProgram {
             pub shared_program_data: SharedProgramData,
@@ -89,6 +93,10 @@ impl<'de> Deserialize<'de> for Program {
         }
 
         let inner_program = InnerProgram::deserialize(deserializer)?;
+
+        //TODO(harsh): remove
+        println!("deserialization succeeded");
+
         Ok(
             Program { shared_program_data: Arc::new(inner_program.shared_program_data),
                 constants: inner_program.constants,


### PR DESCRIPTION
## Description

This PR adds serialization to `Program` and `SharedProgramData` types, which can then be leveraged to add serialization for ContractClass in our blockifier fork.